### PR TITLE
Change requirement pysam to bamnostic for enabling Windows 10 management

### DIFF
--- a/episcanpy/count_matrix/_atac_mtx.py
+++ b/episcanpy/count_matrix/_atac_mtx.py
@@ -1,4 +1,4 @@
-import pysam
+import bamnostic as bm
 import numpy as np
 import anndata as ad
 import pandas as pd
@@ -85,7 +85,7 @@ def bld_atac_mtx(list_bam_files, loaded_feat, output_file_name=None,
     
         ## PART 1 read the bam file
         keep_lines = []
-        samfile = pysam.AlignmentFile(path+output_file_name, mode="rb", check_sq=False)
+        samfile = bm.AlignmentFile(path+output_file_name, mode="rb", check_sq=False)
         for read in samfile.fetch(until_eof=True):
             line = str(read).split('\t')
             if line[2] in chromosomes:

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,5 @@ natsort
 joblib
 numba>=0.41.0
 pysam
+bamnostic
 umap-learn>=0.3.0


### PR DESCRIPTION
To be able to use epiScanpy on Windows 10 we need to change` pysam` dependency to `bamnostic:`
[bamnostic website](https://pypi.org/project/bamnostic/)

Otherwise the pysam library cannot run due to impossibility of installing htslib on windows 10
[GitHub issue 86](https://github.com/samtools/htslib/issues/86)