### PR TITLE
remove version pinning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
-anndata==0.6.22rc1
-scanpy==1.4.4
+anndata
+scanpy
 matplotlib>=3.0.0
 pandas>=0.21
-scipy<=1.3
+scipy
 seaborn
-h5py!=2.10.0
-scikit-learn>=0.19.1, != 0.21.0, != 0.21.1
+h5py
+scikit-learn
 statsmodels
 networkx
 natsort


### PR DESCRIPTION
In order to use episcanpy with the latest scanpy and anndata versions, I have removed the version pinnings in episcanpy and so far did not have any problems.