### PR TITLE
Update _load_matrix.py

### DIFF
--- a/episcanpy/preprocessing/_load_matrix.py
+++ b/episcanpy/preprocessing/_load_matrix.py
@@ -25,7 +25,6 @@ def read_ATAC_10x(matrix, cell_names='', var_names='', path_file=''):
 
     
     mat = mmread(''.join([path_file, matrix]))
-    mat = mat.toarray()
     mat = np.matrix(mat.transpose())
     
     with open(path_file+cell_names) as f:


### PR DESCRIPTION
Removed `mat = mat.toarray()` - the matrix is already in numpy.array format upon being loaded using mmread. Throws an error unless this step is removed. 