### PR TITLE
add patch for chromosomes not found in gtf

### DIFF
--- a/episcanpy/tools/_find_genes.py
+++ b/episcanpy/tools/_find_genes.py
@@ -75,5 +75,7 @@ def find_genes(adata,
                     gene_index.append(gene_name[0])
                 else:
                     gene_index.append(";".join(list(set(gene_name))))
-                    
+        else:
+            undetermined = [gene_index.append(i) for i in np.full(len(raw_adata_features[chrom]), 'undetermined')]
+            
     adata.var[key_added] = gene_index


### PR DESCRIPTION
Some chromosomes in AnnData are not found in the gtf. In this case, nothing is appended to `gene_index` and this prevents `gene_annotations` from being merged into adata.var DataFrame. 

I tested this with outputs from CellRanger 2.0 and the matching genes.gtf file.