### PR TITLE
speed up gene_activity using Intervall tree

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,8 +4,8 @@ channels:
     - conda-forge
     - defaults
 dependencies:
-    - intervaltree
     - python<3.8
+    - intervaltree
     - anndata>=0.7
     - scanpy>=1.5.1
     - importlib_metadata>=0.7

--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ channels:
     - conda-forge
     - defaults
 dependencies:
+    - intervaltree
     - python<3.8
     - anndata>=0.7
     - scanpy>=1.5.1

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,6 @@ channels:
     - defaults
 dependencies:
     - python<3.8
-    - intervaltree
     - anndata>=0.7
     - scanpy>=1.5.1
     - importlib_metadata>=0.7
@@ -29,3 +28,5 @@ dependencies:
     - legacy-api-wrap
     - setuptools_scm
     - packaging
+    - pip:
+        - intervaltree

--- a/episcanpy/tools/_geneactivity.py
+++ b/episcanpy/tools/_geneactivity.py
@@ -110,7 +110,7 @@ def geneactivity(adata,
     copy : unused
 
 
-    OUTPUT
+    OUTPUT anndata object with csc_sparse gene_activity
     ------
 
 
@@ -184,4 +184,5 @@ def geneactivity(adata,
     gene_adata.uns = adata.uns.copy()
     gene_adata.obsm = adata.obsm.copy()
     gene_adata.obsp = adata.obsp.copy()
+
     return(gene_adata)

--- a/episcanpy/tools/_geneactivity.py
+++ b/episcanpy/tools/_geneactivity.py
@@ -162,19 +162,6 @@ def geneactivity(adata,
         for key in metadata_genes.keys():
             metadata_genes[key].append(gene_annotation.get(key, "NA"))
 
-
-    for line in genes_index:
-            dico_line = {}
-            for element in line:
-                if ' "' in element:
-                    dico_line[element.rstrip('"').lstrip(" ").split(' "')[0]] = element.rstrip('"').lstrip(" ").split(' "')[1]
-
-            for key in metadata_genes.keys():
-                if key in dico_line.keys():
-                    metadata_genes[key].append(dico_line[key])
-                else:
-                    metadata_genes[key].append('NA')
-
     # manage index
     dataframe_genes = pd.DataFrame.from_dict(metadata_genes)
     index_col = []
@@ -193,7 +180,9 @@ def geneactivity(adata,
         dataframe_genes.index = pd.Index(dataframe_genes[index_col[0]])
         dataframe_genes = dataframe_genes.drop(index_col, axis=1)
 
-    gene_adata = ad.AnnData(gene_activity, var=dataframe_genes, obs=adata_raw.obs)
+    print(dataframe_genes)
+
+    gene_adata = ad.AnnData(gene_activity, var=dataframe_genes, obs=adata.obs)
     gene_adata.uns = adata.uns.copy()
     gene_adata.obsm = adata.obsm.copy()
     gene_adata.obsp = adata.obsp.copy()

--- a/episcanpy/tools/_geneactivity.py
+++ b/episcanpy/tools/_geneactivity.py
@@ -1,4 +1,3 @@
-import scanpy as sc
 import anndata as ad
 import numpy as np
 import pandas as pd

--- a/episcanpy/tools/_geneactivity.py
+++ b/episcanpy/tools/_geneactivity.py
@@ -180,8 +180,6 @@ def geneactivity(adata,
         dataframe_genes.index = pd.Index(dataframe_genes[index_col[0]])
         dataframe_genes = dataframe_genes.drop(index_col, axis=1)
 
-    print(dataframe_genes)
-
     gene_adata = ad.AnnData(gene_activity, var=dataframe_genes, obs=adata.obs)
     gene_adata.uns = adata.uns.copy()
     gene_adata.obsm = adata.obsm.copy()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 anndata>=0.7
 scanpy>=1.7.0
 importlib_metadata>=0.7; python_version < '3.8'
+intervaltree
 matplotlib>=3.1.2
 pandas>=0.21
 scipy>=1.4


### PR DESCRIPTION
Using a data structure called intervall tree, and a more suited sparse data structure for columns slicing. Obtained a large speed up.

Furthermore small fix: 
- Read gtf should work for all annotations, features and gtf files 
- There are a potential issue with returning a named index of the .var Warning may still pop up as some index value may bot be unique. IMO we should either make them unique or stick to range index.
Tested on a mac book pro and a linux ubuntu. Should work on windows to.