### PR TITLE
change python-igraph to igraph

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,8 @@ setup(
         Path('requirements.txt').read_text('utf-8').splitlines()
     ],
     extras_require=dict(
-        louvain=['python-igraph', 'louvain>=0.6'],
-        leiden=['python-igraph', 'leidenalg'],
+        louvain=['igraph', 'louvain>=0.6'],
+        leiden=['igraph', 'leidenalg'],
         bbknn=['bbknn'],
         combat=['patsy'],
         doc=['sphinx', 'sphinx_rtd_theme', 'sphinx_autodoc_typehints', 'scanpydoc'],


### PR DESCRIPTION
Please see https://github.com/igraph/python-igraph/issues/699 for the reasoning.

Please also check if a change here is necessary:

https://github.com/colomemaria/epiScanpy/blob/master/episcanpy/logging.py#L130

Note that on conda-forge the name stays `python-igraph`. This affects only PyPI.